### PR TITLE
Bumped version of evidence with the Docker dev env fix

### DIFF
--- a/analyze/evidence/package.json
+++ b/analyze/evidence/package.json
@@ -12,6 +12,6 @@
   },
   "type": "module",
   "dependencies": {
-    "@evidence-dev/evidence": "^1.0.1"
+    "@evidence-dev/evidence": "^1.0.2"
   }
 }


### PR DESCRIPTION
@aaronsteers 
Applying this patch to your branch should do.

Thereafter, you'll have to run the docker startup command from  analyze/evidence 

i.e
```
cd analyze/evidence 
evidence % docker run -v=$(pwd):/evidence-workspace -p=3000:3000 -it --platform linux/amd64 --rm evidencedev/devenv:latest
```


You can also use https://github.com/evidence-dev/docker-devenv/blob/main/start-devenv.sh instead of the docker command if it makes things simpler, and pass any arguments you like (e.g `bash`).